### PR TITLE
Fix log message query parameter

### DIFF
--- a/AppFlip-Sample-iOS/AppFlipViewController.swift
+++ b/AppFlip-Sample-iOS/AppFlipViewController.swift
@@ -23,7 +23,7 @@ class AppFlipViewController: UIViewController {
 
   override func viewDidLoad() {
     logField.text.append(
-      "Received\nclientID = \(flipData["clientID"]!)\nscopes = \(flipData["scope"]!)" +
+      "Received\nclientID = \(flipData["clientID"]!)\nscope = \(flipData["scope"]!)" +
       "\nstate = \(flipData["state"]!)\nredirect_URI = \(flipData["redirectUri"]!)\n")
   }
 


### PR DESCRIPTION
The expected query parameter is `scope` not `scopes`.
We should update this to help avoid confusion when testing.